### PR TITLE
Add `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2025-07-29"


### PR DESCRIPTION
Ensures that a toolchain is picked that can actually compile the thing. My system has stable toolchain as default, so without the toolchain spec the install scripted bailed out due to use of nightly features.